### PR TITLE
Feature/framerate independence

### DIFF
--- a/include/Event.hpp
+++ b/include/Event.hpp
@@ -9,6 +9,22 @@
 namespace CoffeeMaker {
   class Event;
 
+  /**
+   * Generic Application level events
+   */
+  enum ApplicationEvents {
+    COFFEEMAKER_GAME_PAUSE,
+    COFFEEMAKER_GAME_UNPAUSE,
+    COFFEEMAKER_SCENE_LOAD,
+    COFFEEMAKER_SCENE_UNLOAD
+  };
+
+  /**
+   * Constructs an SDL_USEREVENT based on the enum and pushes it
+   * into the SDL_Event queue.
+   */
+  void PushCoffeeMakerEvent(ApplicationEvents appEvent);
+
   class Delegate {
     public:
     explicit Delegate(std::function<void(const Event& event)> fn);

--- a/include/FPS.hpp
+++ b/include/FPS.hpp
@@ -1,6 +1,7 @@
 #ifndef _coffeemaker_fps_hpp
 #define _coffeemaker_fps_hpp
 
+#include "Utilities.hpp"
 #include "Widgets/Text.hpp"
 #include "Widgets/View.hpp"
 
@@ -18,7 +19,7 @@ namespace CoffeeMaker {
 
     private:
     View _view{50, 50};
-    Text _text;
+    Ref<Text> _text;
     unsigned int _countedFrames;
     const unsigned int _msInASecond = 1000;
     unsigned int _priorTime;

--- a/include/Game/Enemy.hpp
+++ b/include/Game/Enemy.hpp
@@ -14,7 +14,7 @@ class Enemy : public Entity {
   virtual ~Enemy();
 
   void Init();
-  void Update();
+  void Update(float deltaTime);
   void Render();
   void Spawn();
   bool IsActive() const;

--- a/include/Game/Entity.hpp
+++ b/include/Game/Entity.hpp
@@ -6,7 +6,7 @@ enum class EnemyAnimationState { Idle, Moving };
 class Entity {
   public:
   virtual void Init() = 0;
-  virtual void Update() = 0;
+  virtual void Update(float deltaTime = 0.0f) = 0;
   virtual void Render() = 0;
 
   virtual ~Entity() = 0;

--- a/include/Game/Player.hpp
+++ b/include/Game/Player.hpp
@@ -14,7 +14,7 @@ class Player : public Entity {
   virtual ~Player();
 
   void Init();
-  void Update();
+  void Update(float deltaTime);
   void Render();
   void Fire();
   void Reload();

--- a/include/Game/Projectile.hpp
+++ b/include/Game/Projectile.hpp
@@ -16,7 +16,7 @@ class Projectile {
 
   void Fire(float initialXPosition, float initialYPosition, double rotation);
   void Reload();
-  void Update();
+  void Update(float deltaTime);
   void Render();
   bool IsOffScreen() const;
   void OnHit(Collider* collider);

--- a/include/Game/Scene.hpp
+++ b/include/Game/Scene.hpp
@@ -10,7 +10,7 @@ class Scene {
   virtual ~Scene();
 
   virtual void Render() = 0;
-  virtual void Update() = 0;
+  virtual void Update(float deltaTime) = 0;
   virtual void Init() = 0;
   virtual void Destroy() = 0;
 
@@ -22,7 +22,7 @@ class Scene {
 
 class SceneManager {
   public:
-  static void UpdateCurrentScene();
+  static void UpdateCurrentScene(float deltaTime);
   static void RenderCurrentScene();
   static void LoadScene();
   static void LoadScene(unsigned long index);

--- a/include/Game/Scenes/MainScene.hpp
+++ b/include/Game/Scenes/MainScene.hpp
@@ -13,7 +13,7 @@ class MainScene : public Scene {
   public:
   MainScene();
   virtual void Render();
-  virtual void Update();
+  virtual void Update(float deltaTime);
   virtual void Init();
   virtual void Destroy();
 

--- a/include/Game/Scenes/TitleScene.hpp
+++ b/include/Game/Scenes/TitleScene.hpp
@@ -9,7 +9,7 @@
 class TitleScene : public Scene {
   public:
   virtual void Render();
-  virtual void Update();
+  virtual void Update(float deltaTime);
   virtual void Init();
   virtual void Destroy();
 

--- a/src/Event.cpp
+++ b/src/Event.cpp
@@ -1,5 +1,7 @@
 #include "Event.hpp"
 
+#include <SDL2/SDL.h>
+
 #include <algorithm>
 #include <iostream>
 
@@ -8,6 +10,14 @@
 using namespace CoffeeMaker;
 
 int Delegate::_uid = 0;
+
+void CoffeeMaker::PushCoffeeMakerEvent(CoffeeMaker::ApplicationEvents appEvent) {
+  SDL_UserEvent userevent{.type = SDL_USEREVENT, .code = appEvent, .data1 = nullptr, .data2 = nullptr};
+  SDL_Event event;
+  event.type = SDL_USEREVENT;
+  event.user = userevent;
+  SDL_PushEvent(&event);
+}
 
 Delegate::Delegate(std::function<void(const Event& event)> cb) {
   _function = cb;

--- a/src/FPS.cpp
+++ b/src/FPS.cpp
@@ -8,16 +8,16 @@
 using namespace CoffeeMaker;
 using namespace CoffeeMaker::UIProperties;
 
-FPS::FPS() {
+FPS::FPS() : _text(std::make_shared<Text>("00")) {
   _priorTime = SDL_GetTicks();
   _currentTime = _priorTime;
 
-  _text.SetFont(FontManager::UseFont("Roboto/Roboto-Regular"));
-  _text.SetText("00");
-  _text.SetColor(Color(255, 255, 0, 255));  // Yellow
-  _text.SetHorizontalAlignment(HorizontalAlignment::Centered);
-  _text.SetVerticalAlignment(VerticalAlignment::Bottom);
-  // _view.AppendChild(std::make_shared<UIComponent>(&_text));
+  _text->SetFont(FontManager::UseFont("Roboto/Roboto-Regular"));
+  _text->SetColor(Color(255, 255, 0, 255));  // Yellow
+  _text->SetHorizontalAlignment(HorizontalAlignment::Centered);
+  _text->SetVerticalAlignment(VerticalAlignment::Centered);
+  _view.AppendChild(_text);
+  _view.SetVerticalAlignment(VerticalAlignment::Bottom);
 }
 
 FPS::~FPS() {}
@@ -27,7 +27,7 @@ void FPS::Update() {
   _currentTime = SDL_GetTicks();
 
   if (_currentTime - _priorTime >= _msInASecond) {
-    _text.SetText(std::to_string(_countedFrames));
+    _text->SetText(std::to_string(_countedFrames));
     _priorTime = _currentTime;
     _countedFrames = 0;
   }

--- a/src/Game/Enemy.cpp
+++ b/src/Game/Enemy.cpp
@@ -32,7 +32,7 @@ void Enemy::Render() {
   _collider->Render();
 }
 
-void Enemy::Update() {
+void Enemy::Update(float deltaTime) {
   if (_active) {
     _ticks = SDL_GetTicks();
     if (_ticks > _priorTicks + 750) {
@@ -46,8 +46,8 @@ void Enemy::Update() {
       _priorTicks = _ticks;
     }
 
-    _clientRect.x += _movement.x;
-    _clientRect.y += _movement.y;
+    _clientRect.x += _movement.x * 60 * deltaTime;
+    _clientRect.y += _movement.y * 60 * deltaTime;
     _collider->Update(_clientRect);
 
     if (!_enteredScreen && !IsOffScreen()) {

--- a/src/Game/Player.cpp
+++ b/src/Game/Player.cpp
@@ -57,7 +57,7 @@ void Player::UpdateRespawnImmunity() {
   }
 }
 
-void Player::Update() {
+void Player::Update(float deltaTime) {
   UpdateRespawnImmunity();
 
   if (!_active) {
@@ -77,15 +77,15 @@ void Player::Update() {
     }
 
     SDL_GetMouseState(&_mouseX, &_mouseY);
-    int xx = _mouseX - (int)_clientRect.x;
-    int yy = _mouseY - (int)_clientRect.y;
+    float xx = (_mouseX - _clientRect.x) * deltaTime;
+    float yy = (_mouseY - _clientRect.y) * deltaTime;
 
-    _rotation = glm::degrees(glm::atan((float)yy, (float)xx));
+    _rotation = glm::degrees(glm::atan(yy, xx));
   }
 
   // NOTE: projectiles that have already been fired are still fine to be updated
   for (auto& projectile : _projectiles) {
-    projectile->Update();
+    projectile->Update(deltaTime);
   }
 }
 

--- a/src/Game/Projectile.cpp
+++ b/src/Game/Projectile.cpp
@@ -40,10 +40,10 @@ void Projectile::Render() {
   }
 }
 
-void Projectile::Update() {
+void Projectile::Update(float deltaTime) {
   if (_fired) {
-    _clientRect.x += _movement.x * 5;
-    _clientRect.y += _movement.y * 5;
+    _clientRect.x += _movement.x * 150 * deltaTime;
+    _clientRect.y += _movement.y * 150 * deltaTime;
 
     // NOTE: probably want this separated out
     collider->Update(_clientRect);

--- a/src/Game/Scene.cpp
+++ b/src/Game/Scene.cpp
@@ -1,5 +1,6 @@
 #include "Game/Scene.hpp"
 
+#include "Event.hpp"
 #include "Game/Enemy.hpp"
 #include "Game/Player.hpp"
 
@@ -7,7 +8,7 @@ int SceneManager::_currentSceneIndex = -1;
 std::vector<Scene*> SceneManager::scenes = {};
 Scene* SceneManager::_currentScene = nullptr;
 
-void SceneManager::UpdateCurrentScene() { _currentScene->Update(); }
+void SceneManager::UpdateCurrentScene(float deltaTime) { _currentScene->Update(deltaTime); }
 
 void SceneManager::RenderCurrentScene() { _currentScene->Render(); }
 
@@ -18,6 +19,7 @@ void SceneManager::LoadScene() {
   if (_currentSceneIndex == -1) {
     _currentScene = scenes[++_currentSceneIndex];
     _currentScene->Init();
+    CoffeeMaker::PushCoffeeMakerEvent(CoffeeMaker::ApplicationEvents::COFFEEMAKER_SCENE_LOAD);
     return;
   }
   // NOTE: If not the first scene, clean up and then move to next scene
@@ -30,6 +32,7 @@ void SceneManager::LoadScene() {
     _currentScene = scenes[_currentSceneIndex];
   }
   _currentScene->Init();
+  CoffeeMaker::PushCoffeeMakerEvent(CoffeeMaker::ApplicationEvents::COFFEEMAKER_SCENE_LOAD);
 }
 
 void SceneManager::LoadScene(unsigned long index) {
@@ -38,6 +41,7 @@ void SceneManager::LoadScene(unsigned long index) {
     _currentSceneIndex = index;
     _currentScene = scenes[_currentSceneIndex];
     _currentScene->Init();
+    CoffeeMaker::PushCoffeeMakerEvent(CoffeeMaker::ApplicationEvents::COFFEEMAKER_SCENE_LOAD);
   }
 }
 

--- a/src/Game/Scenes/MainScene.cpp
+++ b/src/Game/Scenes/MainScene.cpp
@@ -1,5 +1,8 @@
 #include "Game/Scenes/MainScene.hpp"
 
+#include <SDL2/SDL.h>
+
+#include "Event.hpp"
 #include "Game/Collider.hpp"
 #include "InputManager.hpp"
 
@@ -17,11 +20,13 @@ void MainScene::Render() {
   _menu->Render();
 }
 
-void MainScene::Update() {
+void MainScene::Update(float deltaTime) {
   if (CoffeeMaker::InputManager::IsKeyPressed(SDL_SCANCODE_ESCAPE)) {
     if (_menu->IsShown()) {
+      CoffeeMaker::PushCoffeeMakerEvent(CoffeeMaker::ApplicationEvents::COFFEEMAKER_GAME_UNPAUSE);
       _menu->Hide();
     } else {
+      CoffeeMaker::PushCoffeeMakerEvent(CoffeeMaker::ApplicationEvents::COFFEEMAKER_GAME_PAUSE);
       _menu->Show();
     }
   }
@@ -30,11 +35,11 @@ void MainScene::Update() {
     if (!enemy->IsActive()) {
       enemy->Spawn();
     }
-    enemy->Update();
+    enemy->Update(deltaTime);
   }
 
   for (auto& entity : _entities) {
-    entity->Update();
+    entity->Update(deltaTime);
   }
 
   _hud->Update();
@@ -46,7 +51,6 @@ void MainScene::Init() {
   _menu->Init();
   _backgroundTiles = new Tiles("space.png", 800, 600);
   _player = new Player();
-  // _enemies = {};
 
   for (unsigned int i = 0; i < MAX_ENEMIES; i++) {
     _enemies[i] = std::make_shared<Enemy>();

--- a/src/Game/Scenes/TitleScene.cpp
+++ b/src/Game/Scenes/TitleScene.cpp
@@ -26,7 +26,7 @@ void TitleScene::Render() {
   }
 }
 
-void TitleScene::Update() {}
+void TitleScene::Update(float) {}
 
 void TitleScene::Init() {
   _backgroundColor = Color(0, 0, 0, 255);  // Black

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -57,9 +57,9 @@ bool Timer::IsStarted() { return _started; }
 std::string Timer::toString() {
   float totalSeconds = GetTicks() / 1000.0f;
   float totalMinutes = totalSeconds / 60;
-  int integerMinutes = totalMinutes;
+  int integerMinutes = (int)totalMinutes;
   float remainingSeconds = totalMinutes - integerMinutes;
-  int integerSeconds = remainingSeconds * 60;
+  int integerSeconds = (int)remainingSeconds * 60;
 
   return std::string(std::to_string(integerMinutes) + ":" + std::to_string(integerSeconds));
 }


### PR DESCRIPTION
This PR introduces framerate independence to the game code. Also provides some generic events to pause/unpause the game. SceneManager will push Scene Load events which can also unpause the game. A global timer is present in the core game loop and it's delta time is passed down to the current scene, from there the current scene can call `Update` on any Entity with a `deltaTime` floating point value and the entity can leverage the `deltaTime` as part of it's movement/physics update.