### PR TITLE
Bugfix/player destroyed multi times

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -114,7 +114,8 @@
     "__bits": "cpp",
     "__tree": "cpp",
     "complex": "cpp",
-    "future": "cpp"
+    "future": "cpp",
+    "source_location": "cpp"
   },
   "cmake.configureSettings": {
     "CMAKE_TOOLCHAIN_FILE": "~/vcpkg/scripts/buildsystems/vcpkg.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ target_link_libraries(main PRIVATE fmt::fmt spdlog::spdlog spdlog::spdlog_header
 if (WIN32)
   message("Building for Win32")
   target_link_libraries(main PRIVATE SDL2::SDL2 SDL2::SDL2main SDL2::SDL2_ttf SDL2::SDL2_image SDL2::SDL2_mixer)
+
+  target_compile_definitions(main PRIVATE COFFEEMAKER_LOGGER_SOURCE_LOCATION)
 elseif(APPLE)
   message("Building for OSX")
   find_package(Ogg CONFIG REQUIRED)
@@ -101,6 +103,8 @@ elseif(APPLE)
   target_link_libraries(main PRIVATE SDL2::SDL2main SDL2::SDL2-static SDL2::SDL2_ttf SDL2::SDL2_image SDL2::SDL2_mixer)
   target_link_libraries(main PRIVATE Vorbis::vorbis Vorbis::vorbisenc Vorbis::vorbisfile)
   target_link_libraries(main PRIVATE MPG123::libmpg123 MPG123::libout123 MPG123::libsyn123)
+
+  target_compile_definitions(main PRIVATE COFFEEMAKER_LOGGER_SOURCE_LOCATION)
 elseif(LINUX_PLATFORM)
   message("Linking dependencies for Linux")
   add_compile_definitions(_FILE_OFFSET_BITS=64)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,6 @@ elseif(APPLE)
   target_link_libraries(main PRIVATE SDL2::SDL2main SDL2::SDL2-static SDL2::SDL2_ttf SDL2::SDL2_image SDL2::SDL2_mixer)
   target_link_libraries(main PRIVATE Vorbis::vorbis Vorbis::vorbisenc Vorbis::vorbisfile)
   target_link_libraries(main PRIVATE MPG123::libmpg123 MPG123::libout123 MPG123::libsyn123)
-
-  target_compile_definitions(main PRIVATE COFFEEMAKER_LOGGER_SOURCE_LOCATION)
 elseif(LINUX_PLATFORM)
   message("Linking dependencies for Linux")
   add_compile_definitions(_FILE_OFFSET_BITS=64)

--- a/include/Async.hpp
+++ b/include/Async.hpp
@@ -103,7 +103,7 @@ namespace CoffeeMaker {
               if (_timer->Expired()) {
                 // CM_LOGGER_INFO("{} Completed, {} Ticks compared to {} duration", _name, _timer->GetTicks(),
                 //                _timer->GetInterval());
-                _callback();
+                // _callback();
                 _running = false;
                 return;
               }
@@ -204,7 +204,7 @@ namespace CoffeeMaker {
               std::this_thread::sleep_for(std::chrono::milliseconds(16));
               std::lock_guard<std::mutex> lk(*_mutex);
               if (_timer->Expired()) {
-                _callback();
+                // _callback();
                 _timer->Reset();
               }
             }

--- a/include/Async.hpp
+++ b/include/Async.hpp
@@ -69,7 +69,7 @@ namespace CoffeeMaker {
         }
       }
 
-      void Start2() {
+      void Start() {
         if (!_running) {
           _running = true;
           _canceled = false;
@@ -90,32 +90,6 @@ namespace CoffeeMaker {
         }
       }
 
-      void Start() {
-        if (!_running) {
-          _running = true;
-          _canceled = false;
-          _future = std::async(std::launch::async, [this] {
-            _timer->Start();
-            // CM_LOGGER_INFO("{} Started on thread", _name);
-            while (!_canceled) {
-              std::this_thread::sleep_for(std::chrono::milliseconds(16));
-              std::lock_guard<std::mutex> lk(*_timeoutMutex);
-              if (_timer->Expired()) {
-                // CM_LOGGER_INFO("{} Completed, {} Ticks compared to {} duration", _name, _timer->GetTicks(),
-                //                _timer->GetInterval());
-                // _callback();
-                _running = false;
-                return;
-              }
-              // CM_LOGGER_INFO("{} Keep going", _name);
-            }
-            _running = false;
-            // CM_LOGGER_INFO("{} Canceled thread", _name);
-            return;
-          });
-        }
-      }
-
       void Reset() {
         _canceled = false;
         _running = false;
@@ -124,18 +98,20 @@ namespace CoffeeMaker {
       void Cancel() {
         std::lock_guard<std::mutex> lk(*_timeoutMutex);
         _canceled = true;
+        CoffeeMaker::Logger::Trace(
+            fmt::format(fmt::runtime("[TIMEOUT][{}] Canceled at {}"), _name, _timer->GetTicks()));
       }
 
       void Pause() {
         std::lock_guard<std::mutex> lk(*_timeoutMutex);
         _timer->Pause();
-        // CM_LOGGER_INFO("{} Paused at {}", _name, _timer->GetTicks());
+        CoffeeMaker::Logger::Trace(fmt::format(fmt::runtime("[TIMEOUT][{}] Paused at {}"), _name, _timer->GetTicks()));
       }
 
       void Unpause() {
         std::lock_guard<std::mutex> lk(*_timeoutMutex);
         _timer->Unpause();
-        // CM_LOGGER_INFO("{} Resumed at {}", _name, _timer->GetTicks());
+        CoffeeMaker::Logger::Trace(fmt::format(fmt::runtime("[TIMEOUT][{}] Resumed at {}"), _name, _timer->GetTicks()));
       }
 
       private:
@@ -169,7 +145,7 @@ namespace CoffeeMaker {
         }
       }
 
-      void Start2() {
+      void Start() {
         if (!_running) {
           _running = true;
           _canceled = false;
@@ -190,42 +166,25 @@ namespace CoffeeMaker {
         }
       }
 
-      /**
-       * @brief This function is deprecated, use Start2 instead to leverage std::thread directly
-       * @deprecated Do not use, leverage Start2() instead
-       */
-      void Start() {
-        if (!_running) {
-          _running = true;
-          _future = std::async(std::launch::async | std::launch::deferred, [this] {
-            _canceled = false;
-            _timer->Start();
-            while (!_canceled) {
-              std::this_thread::sleep_for(std::chrono::milliseconds(16));
-              std::lock_guard<std::mutex> lk(*_mutex);
-              if (_timer->Expired()) {
-                // _callback();
-                _timer->Reset();
-              }
-            }
-            _running = false;
-          });
-        }
-      }
-
       void Cancel() {
         std::lock_guard<std::mutex> lk(*_mutex);
         _canceled = true;
+        CoffeeMaker::Logger::Trace(
+            fmt::format(fmt::runtime("[INTERVAL][undefined] Resumed at {}"), _timer->GetTicks()));
       }
 
       void Pause() {
         std::lock_guard<std::mutex> lk(*_mutex);
         _timer->Pause();
+        CoffeeMaker::Logger::Trace(
+            fmt::format(fmt::runtime("[INTERVAL][undefined] Resumed at {}"), _timer->GetTicks()));
       }
 
       void Unpause() {
         std::lock_guard<std::mutex> lk(*_mutex);
         _timer->Unpause();
+        CoffeeMaker::Logger::Trace(
+            fmt::format(fmt::runtime("[INTERVAL][undefined] Resumed at {}"), _timer->GetTicks()));
       }
 
       private:

--- a/include/Game/Collider.hpp
+++ b/include/Game/Collider.hpp
@@ -37,6 +37,8 @@ class Collider {
   Type GetType() const;
   void SetType(Collider::Type type);
 
+  std::string ToString();
+
   SDL_FRect clientRect;
   bool active;
 

--- a/include/Game/Collider.hpp
+++ b/include/Game/Collider.hpp
@@ -12,6 +12,20 @@
 class Collider {
   public:
   enum class Type { Default, Projectile, Enemy, Player, EnemyProjectile };
+  std::string ColliderTypeString(Collider::Type type) {
+    switch (type) {
+      case Collider::Type::Projectile:
+        return "Projectile";
+      case Collider::Type::Enemy:
+        return "Enemy";
+      case Collider::Type::Player:
+        return "Player";
+      case Collider::Type::EnemyProjectile:
+        return "EnemyProjectile";
+      default:
+        return "Default";
+    }
+  }
   static void PhysicsUpdate();
   static void ProcessCollisions();
   /**

--- a/include/Game/Player.hpp
+++ b/include/Game/Player.hpp
@@ -23,6 +23,8 @@ class Player : public Entity, public CoffeeMaker::IUserEventListener {
 
   public:
   static CoffeeMaker::Math::Vector2D Position();
+  // NOTE: This is to keep track of stupid developers doing stupid things.
+  static Player* _instance;
 
   public:
   Player();
@@ -61,7 +63,6 @@ class Player : public Entity, public CoffeeMaker::IUserEventListener {
   unsigned int _lives;
   glm::vec2 _direction{1.0f, 0.0f};
   int _speed = 225;
-  static Player* _instance;
   Scope<UCI::Animations::ExplodeSpriteAnimation> _destroyedAnimation;
   Scope<CoffeeMaker::Async::TimeoutTask> _asyncRespawnTask;
   Scope<CoffeeMaker::Async::TimeoutTask> _asyncImmunityTask;
@@ -69,7 +70,6 @@ class Player : public Entity, public CoffeeMaker::IUserEventListener {
   Scope<CoffeeMaker::Math::Oscillate> _oscillation;
   Scope<CoffeeMaker::Async::TimeoutTask> _fireDelay;
   Player::FireMissileState _fireMissileState;
-  Scope<CoffeeMaker::SDLTimer> _fireSDLDelay;
 };
 
 #endif

--- a/include/Game/Player.hpp
+++ b/include/Game/Player.hpp
@@ -44,7 +44,7 @@ class Player : public Entity, public CoffeeMaker::IUserEventListener {
   void UpdateRespawnImmunity();
   bool IsOffScreenLeft();
   bool IsOffScreenRight();
-  void HandleDestroy();
+  void HandleDestroy(Collider* collider);
 
   CoffeeMaker::Texture _texture{"PlayerV1.png", true};
   SDL_Rect _clipRect{.x = 0, .y = 0, .w = 32, .h = 32};

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -6,7 +6,9 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
+#ifdef COFFEEMAKER_LOGGER_SOURCE_LOCATION
 #include <source_location>
+#endif
 
 namespace CoffeeMaker {
   class Logger {
@@ -14,8 +16,12 @@ namespace CoffeeMaker {
     static void Init();
     static spdlog::logger *Instance();
     static void Trace(fmt::v8::format_string<> fmt);
+#ifdef COFFEEMAKER_LOGGER_SOURCE_LOCATION
     static void Debug(fmt::v8::format_string<> fmt,
                       const std::source_location &location = std::source_location::current());
+#else
+    static void Debug(fmt::v8::format_string<> fmt);
+#endif
     static void Warn(fmt::v8::format_string<> fmt);
     static void Info(fmt::v8::format_string<> fmt);
     static void Error(fmt::v8::format_string<> fmt);

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -1,40 +1,43 @@
 #ifndef _coffeemaker_logger_hpp
 #define _coffeemaker_logger_hpp
 
+#include <fmt/core.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
-namespace CoffeeMaker {
-class Logger {
- public:
-  static void Init();
-  static spdlog::logger *Instance();
-  static void Trace(std::string msg);
-  static void Debug(std::string msg);
-  static void Warn(std::string msg);
-  static void Info(std::string msg);
-  static void Error(std::string msg);
-  static void Critical(std::string msg);
-  static void Destroy();
+#include <source_location>
 
- private:
-  Logger();
-  ~Logger();
-  std::shared_ptr<spdlog::sinks::basic_file_sink_mt> _fileSink;
-  std::shared_ptr<spdlog::sinks::stdout_color_sink_mt> _consoleSink;
-  std::shared_ptr<spdlog::sinks::stderr_color_sink_mt> _errSink;
-  spdlog::logger *_spdlog;
-  static Logger *_logger;
-};
+namespace CoffeeMaker {
+  class Logger {
+    public:
+    static void Init();
+    static spdlog::logger *Instance();
+    static void Trace(fmt::v8::format_string<> fmt);
+    static void Debug(fmt::v8::format_string<> fmt,
+                      const std::source_location &location = std::source_location::current());
+    static void Warn(fmt::v8::format_string<> fmt);
+    static void Info(fmt::v8::format_string<> fmt);
+    static void Error(fmt::v8::format_string<> fmt);
+    static void Critical(fmt::v8::format_string<> fmt);
+    static void Destroy();
+
+    private:
+    Logger();
+    ~Logger();
+    std::shared_ptr<spdlog::sinks::basic_file_sink_mt> _fileSink;
+    std::shared_ptr<spdlog::sinks::stdout_color_sink_mt> _consoleSink;
+    std::shared_ptr<spdlog::sinks::stderr_color_sink_mt> _errSink;
+    spdlog::logger *_spdlog;
+    static Logger *_logger;
+  };
 
 }  // namespace CoffeeMaker
 
 // Logging macros
 #define CM_LOGGER_INIT() CoffeeMaker::Logger::Init()
 #define CM_LOGGER_DESTROY() CoffeeMaker::Logger::Destroy()
-#define CM_LOGGER_CRITICAL(...) \
-  CoffeeMaker::Logger::Instance()->critical(__VA_ARGS__)
+#define CM_LOGGER_CRITICAL(...) CoffeeMaker::Logger::Instance()->critical(__VA_ARGS__)
 #define CM_LOGGER_ERROR(...) CoffeeMaker::Logger::Instance()->error(__VA_ARGS__)
 #define CM_LOGGER_WARN(...) CoffeeMaker::Logger::Instance()->warn(__VA_ARGS__)
 #define CM_LOGGER_INFO(...) CoffeeMaker::Logger::Instance()->info(__VA_ARGS__)

--- a/src/Game/Collider.cpp
+++ b/src/Game/Collider.cpp
@@ -82,7 +82,7 @@ void Collider::OnCollision(Collider* collider) {
 
 void Collider::CheckForCollision() {
   for (auto&& collider : _colliders) {
-    // NOTE: fitler out self
+    // NOTE: fitler out self, make sure the collider is active
     if (collider->_id != _id && collider->active) {
       if (_AxisAlignedBoundingBoxHit(collider)) {
         collisionQueue.push(std::bind(&Collider::OnCollision, this, collider));
@@ -111,6 +111,7 @@ Collider::Type Collider::GetType() const { return _type; }
 void Collider::SetType(Collider::Type type) { _type = type; }
 
 std::string Collider::ToString() {
-  std::string str = fmt::format(fmt::runtime("Collider:[ id={}, type={}, owner=undefined ]"), _id, _type);
+  std::string typeString = ColliderTypeString(_type);
+  std::string str = fmt::format(fmt::runtime("Collider:[ id={}, type={}, owner=undefined ]"), _id, typeString);
   return str;
 }

--- a/src/Game/Collider.cpp
+++ b/src/Game/Collider.cpp
@@ -109,3 +109,8 @@ void Collider::OnCollide(std::function<void(Collider*)> callback) { _listeners.p
 Collider::Type Collider::GetType() const { return _type; }
 
 void Collider::SetType(Collider::Type type) { _type = type; }
+
+std::string Collider::ToString() {
+  std::string str = fmt::format(fmt::runtime("Collider:[ id={}, type={}, owner=undefined ]"), _id, _type);
+  return str;
+}

--- a/src/Game/Enemy.cpp
+++ b/src/Game/Enemy.cpp
@@ -64,19 +64,18 @@ Enemy::Enemy() :
   _sprite->clientRect.w = 48;
   _sprite->clientRect.h = 48;
   _entranceSpline->OnComplete([this](void*) {
-    // CM_LOGGER_INFO("[ENEMY_EVENT] _entranceSpline Complete Enemy ID: {}", _id);
+    CoffeeMaker::Logger::Trace(
+        fmt::format(fmt::runtime("[ENEMY_EVENT][ENEMY_ENTRANCE_SPLINE] Complete Enemy ID: {}"), _id));
     _state = Enemy::State::StrafingLeft;
-    _fireMissileTask->Start2();
-    // __debugbreak();
-    // CM_LOGGER_INFO("[ENEMY_EVENT] Entrance Animation Complete Enemy ID: {}", _id);
-    _exitTimeoutTask->Start2();
+    _fireMissileTask->Start();
+    _exitTimeoutTask->Start();
   });
   _exitSpline->OnComplete([this](void*) {
-    // CM_LOGGER_INFO("[ENEMY_EVENT] _exitSpline Complete Enemy ID: {}", _id);
+    CoffeeMaker::Logger::Trace(
+        fmt::format(fmt::runtime("[ENEMY_EVENT][ENEMY_EXIT_SPLINE] Complete Enemy ID: {}"), _id));
     _active = false;
     _state = Enemy::State::Idle;
-    // CM_LOGGER_INFO("[ENEMY_EVENT] Exit Animation Complete Enemy ID: {}", _id);
-    _respawnTimeoutTask->Start2();
+    _respawnTimeoutTask->Start();
   });
 
   _collider = CreateScope<Collider>(Collider::Type::Enemy, false);
@@ -90,9 +89,10 @@ Enemy::Enemy() :
   _currentProjectile = 0;
 
   _destroyedAnimation->OnComplete([this] {
-    // CM_LOGGER_INFO("[ENEMY_EVENT] Destroyed Animation Complete - Enemy ID: {}", _id);
+    CoffeeMaker::Logger::Trace(
+        fmt::format(fmt::runtime("[ENEMY_EVENT][ENEMY_DESTROYED_ANIMATION] Complete Enemy ID: {}"), _id));
     _state = Enemy::State::Idle;
-    _respawnTimeoutTask->Start2();
+    _respawnTimeoutTask->Start();
   });
 }
 
@@ -310,8 +310,8 @@ Drone::Drone() {
   _entranceSpline = CreateScope<::Animations::EnemyBriefEntrance>();
   _entranceSpline->OnComplete([this](void*) {
     _state = Enemy::State::StrafingLeft;
-    _fireMissileTask->Start2();
-    _exitTimeoutTask->Start2();
+    _fireMissileTask->Start();
+    _exitTimeoutTask->Start();
   });
 }
 

--- a/src/Game/Player.cpp
+++ b/src/Game/Player.cpp
@@ -29,7 +29,7 @@ Player::Player() :
     _asyncRespawnTask(CreateScope<CoffeeMaker::Async::TimeoutTask>(
         "[PLAYER][RESPAWN-TASK]",
         [] {
-          CM_LOGGER_INFO("[PLAYER_EVENT] - PLAYER_WILL_SPAWN");
+          CoffeeMaker::Logger::Debug("[PLAYER_EVENT] - PLAYER_WILL_SPAWN");
           CoffeeMaker::PushEvent(UCI::Events::PLAYER_POWER_UP_GAINED_IMMUNITY);
           CoffeeMaker::PushEvent(UCI::Events::PLAYER_COMPLETE_SPAWN);
         },
@@ -42,23 +42,16 @@ Player::Player() :
     _fireDelay(CreateScope<CoffeeMaker::Async::TimeoutTask>(
         "[PLAYER][FIRE-MISSILE-DELAY]",
         [] {
-          CM_LOGGER_INFO("[PLAYER_EVENT] - FIRE-MISSILE-DELAY event was pushed");
+          CoffeeMaker::Logger::Debug("[PLAYER_EVENT] - FIRE-MISSILE-DELAY event was pushed");
           CoffeeMaker::PushEvent(UCI::Events::PLAYER_FIRE_DELAY_END);
         },
         250)),
-    _fireMissileState(Player::FireMissileState::Unlocked),
-    _fireSDLDelay(CreateScope<CoffeeMaker::SDLTimer>(
-        250,
-        [](Uint32, void* params) {
-          std::pair<CoffeeMaker::SDLTimer*, Player*>* p =
-              reinterpret_cast<std::pair<CoffeeMaker::SDLTimer*, Player*>*>(params);
-          SDL_LockMutex(p->first->paused);
-          CM_LOGGER_INFO("[PLAYER_EVENT] - SDL Timer is up");
-          CoffeeMaker::PushEvent(UCI::Events::PLAYER_FIRE_DELAY_END);
-          SDL_UnlockMutex(p->first->paused);
-          return static_cast<Uint32>(0);
-        },
-        nullptr)) {
+    _fireMissileState(Player::FireMissileState::Unlocked) {
+  if (_instance != nullptr) {
+    // NOTE: You really messed this one up.
+    CoffeeMaker::Logger::Critical("[PLAYER_EVENT][CONSTRUCTION] - An instance of the player class already exists.");
+    CoffeeMaker::PushEvent(CoffeeMaker::ApplicationEvents::COFFEEMAKER_GAME_QUIT);
+  }
   _firing = false;
   SDL_Rect vp;
   SDL_RenderGetViewport(CoffeeMaker::Renderer::Instance(), &vp);
@@ -72,8 +65,8 @@ Player::Player() :
   _collider->clientRect.w = _clientRect.w;
   _collider->Update(_clientRect);
   _collider->OnCollide(std::bind(&Player::OnHit, this, std::placeholders::_1));
-  _instance = this;
   _destroyedAnimation->OnComplete([] { CoffeeMaker::PushEvent(UCI::Events::PLAYER_BEGIN_SPAWN); });
+  _instance = this;
 }
 
 Player::~Player() {
@@ -81,12 +74,12 @@ Player::~Player() {
   _asyncImmunityTask->Cancel();
   _destroyedAnimation->Stop();
   _fireDelay->Cancel();
-  _fireSDLDelay->Stop();
   _instance = nullptr;
   delete _collider;
   for (auto p : _projectiles) {
     delete p;
   }
+  _instance = nullptr;
 }
 
 void Player::OnHit(Collider* collider) {
@@ -115,10 +108,7 @@ void Player::HandleDestroy(Collider* collider) {
   _lives--;
   CoffeeMaker::PushEvent(UCI::Events::PLAYER_LOST_LIFE);
   CoffeeMaker::PushEvent(UCI::Events::PLAYER_DESTROYED);
-  _destroyed = true;
-  _destroyedAnimation->SetPosition(Vec2{_clientRect.x, _clientRect.y});
-  _destroyedAnimation->Start();
-  CM_LOGGER_INFO("[PLAYER_EVENT]-PLAYER_DESTROYED {}", collider->ToString());
+  CoffeeMaker::Logger::Debug(fmt::format(fmt::runtime("[PLAYER_EVENT]-PLAYER_DESTROYED {}"), collider->ToString()));
 }
 
 void Player::Init() {}
@@ -135,7 +125,6 @@ void Player::Update(float deltaTime) {
       if (_fireMissileState == Player::FireMissileState::Unlocked) {
         Fire();
         _fireDelay->Start2();
-        //_fireSDLDelay->Start();
       }
     }
 
@@ -171,7 +160,7 @@ void Player::Render() {
 
   if (_active) {
     _texture.Render(_clipRect, _clientRect, _rotation + 90);
-    // _collider->Render();
+    _collider->Render();
   }
 
   // NOTE: projectiles that have already been fired are still fine to be rendered
@@ -193,7 +182,7 @@ void Player::Fire() {
     // NOTE: fire the next, or else projectiles are unavailable for a frame.
     _projectiles[_currentProjectile++]->Fire((float)_clientRect.x, (float)_clientRect.y, _rotation);
   }
-  CM_LOGGER_INFO("[PLAYER_EVENT] - FIRED-MISSILE");
+  CoffeeMaker::Logger::Debug("[PLAYER_EVENT] - FIRED-MISSILE");
   _fireMissileState = Player::FireMissileState::Locked;
 }
 
@@ -214,7 +203,6 @@ void Player::OnSDLUserEvent(const SDL_UserEvent& event) {
     _asyncRespawnTask->Pause();
     _asyncImmunityTask->Pause();
     _fireDelay->Pause();
-    _fireSDLDelay->Pause();
     return;
   }
 
@@ -224,7 +212,6 @@ void Player::OnSDLUserEvent(const SDL_UserEvent& event) {
     _asyncRespawnTask->Unpause();
     _asyncImmunityTask->Unpause();
     _fireDelay->Unpause();
-    _fireSDLDelay->Unpause();
     return;
   }
 
@@ -257,7 +244,13 @@ void Player::OnSDLUserEvent(const SDL_UserEvent& event) {
   }
 
   if (event.code == UCI::Events::PLAYER_FIRE_DELAY_END) {
-    CM_LOGGER_INFO("[PLAYER_EVENT] - FIRE-MISSILE-DELAY event was received");
+    CoffeeMaker::Logger::Debug("[PLAYER_EVENT] - FIRE-MISSILE-DELAY event was received");
     _fireMissileState = Player::FireMissileState::Unlocked;
+  }
+
+  if (event.code == UCI::Events::PLAYER_DESTROYED) {
+    _destroyed = true;
+    _destroyedAnimation->SetPosition(CoffeeMaker::Math::Vector2D{_clientRect.x, _clientRect.y});
+    _destroyedAnimation->Start();
   }
 }

--- a/src/Game/Player.cpp
+++ b/src/Game/Player.cpp
@@ -92,18 +92,18 @@ Player::~Player() {
 void Player::OnHit(Collider* collider) {
   if (_collider->active) {
     if (collider->GetType() == Collider::Type::EnemyProjectile && !_isImmune) {
-      HandleDestroy();
+      HandleDestroy(collider);
       return;
     }
 
     if (collider->GetType() == Collider::Type::Enemy && !_isImmune) {
       _impactSound->Play();
-      HandleDestroy();
+      HandleDestroy(collider);
     }
   }
 }
 
-void Player::HandleDestroy() {
+void Player::HandleDestroy(Collider* collider) {
   using Vec2 = CoffeeMaker::Math::Vector2D;
   _collider->active = false;
   _active = false;
@@ -118,7 +118,7 @@ void Player::HandleDestroy() {
   _destroyed = true;
   _destroyedAnimation->SetPosition(Vec2{_clientRect.x, _clientRect.y});
   _destroyedAnimation->Start();
-  CM_LOGGER_INFO("[PLAYER_EVENT] - PLAYER_DESTROYED");
+  CM_LOGGER_INFO("[PLAYER_EVENT]-PLAYER_DESTROYED {}", collider->ToString());
 }
 
 void Player::Init() {}

--- a/src/Game/Player.cpp
+++ b/src/Game/Player.cpp
@@ -97,7 +97,6 @@ void Player::OnHit(Collider* collider) {
 }
 
 void Player::HandleDestroy(Collider* collider) {
-  using Vec2 = CoffeeMaker::Math::Vector2D;
   _collider->active = false;
   _active = false;
   if (_lives - 1 == 0) {
@@ -124,7 +123,7 @@ void Player::Update(float deltaTime) {
     if (CoffeeMaker::InputManager::IsKeyPressed(SDL_SCANCODE_SPACE)) {
       if (_fireMissileState == Player::FireMissileState::Unlocked) {
         Fire();
-        _fireDelay->Start2();
+        _fireDelay->Start();
       }
     }
 
@@ -160,7 +159,7 @@ void Player::Render() {
 
   if (_active) {
     _texture.Render(_clipRect, _clientRect, _rotation + 90);
-    _collider->Render();
+    // _collider->Render();
   }
 
   // NOTE: projectiles that have already been fired are still fine to be rendered
@@ -218,14 +217,14 @@ void Player::OnSDLUserEvent(const SDL_UserEvent& event) {
   if (event.code == UCI::Events::PLAYER_BEGIN_SPAWN) {
     // CM_LOGGER_INFO("[PLAYER_EVENT] - PLAYER_BEGIN_SPAWN");
     _destroyed = false;
-    _asyncRespawnTask->Start2();
+    _asyncRespawnTask->Start();
     return;
   }
 
   if (event.code == UCI::Events::PLAYER_POWER_UP_GAINED_IMMUNITY) {
     // CM_LOGGER_INFO("[PLAYER_EVENT] - PLAYER_POWER_UP_GAINED_IMMUNITY");
     _isImmune = true;
-    _asyncImmunityTask->Start2();
+    _asyncImmunityTask->Start();
     _oscillation->Start();
     return;
   }

--- a/src/Game/Projectile.cpp
+++ b/src/Game/Projectile.cpp
@@ -52,7 +52,7 @@ void Projectile::Render() {
     SDL_RendererFlip flip = SDL_FLIP_NONE;
     SDL_RenderCopyExF(CoffeeMaker::Renderer::Instance(), Projectile::_texture->Handle(), NULL, &_clientRect, _rotation,
                       NULL, flip);
-    collider->Render();
+    // collider->Render();
   }
 }
 

--- a/src/Game/Projectile.cpp
+++ b/src/Game/Projectile.cpp
@@ -52,7 +52,7 @@ void Projectile::Render() {
     SDL_RendererFlip flip = SDL_FLIP_NONE;
     SDL_RenderCopyExF(CoffeeMaker::Renderer::Instance(), Projectile::_texture->Handle(), NULL, &_clientRect, _rotation,
                       NULL, flip);
-    // collider->Render();
+    collider->Render();
   }
 }
 

--- a/src/Game/Scenes/MainScene.cpp
+++ b/src/Game/Scenes/MainScene.cpp
@@ -94,7 +94,7 @@ void MainScene::Init() {
 
   _entities.push_back(_player);
   _loaded = true;
-  _enemySpawnTask->Start();
+  _enemySpawnTask->Start2();
 }
 
 void MainScene::Destroy() {

--- a/src/Game/Scenes/MainScene.cpp
+++ b/src/Game/Scenes/MainScene.cpp
@@ -94,7 +94,7 @@ void MainScene::Init() {
 
   _entities.push_back(_player);
   _loaded = true;
-  _enemySpawnTask->Start2();
+  _enemySpawnTask->Start();
 }
 
 void MainScene::Destroy() {
@@ -124,7 +124,6 @@ void MainScene::OnSDLUserEvent(const SDL_UserEvent& event) {
     switch (event.code) {
       case UCI::Events::ENEMY_INITIAL_INTERVAL_SPAWN: {
         CoffeeMaker::PushEvent(UCI::Events::ENEMY_SPAWNED, _enemies[_currentSpawn++]);
-        // _enemies[_currentSpawn++]->Spawn();
         if (_currentSpawn == MAX_ENEMIES) {
           _enemySpawnTask->Cancel();
         }

--- a/src/Game/Scenes/TestEchelon.cpp
+++ b/src/Game/Scenes/TestEchelon.cpp
@@ -11,7 +11,7 @@ TestEchelonScene::TestEchelonScene() :
     _echelon2(CreateScope<Echelon>(400.0f, 50.0f, 20.0f, 200.0f, "TEST_ECHELON_2")),
     _echelon3(CreateScope<Echelon>(400.0f, 50.0f, 20.0f, 100.0f, "TEST_ECHELON_3")),
     _enemies({}),
-    _player(CreateScope<Player>()),
+    _player(nullptr),
     _currentSpawnIndex(0) {
   _echelon2->SetPosition(CoffeeMaker::Math::Vector2D{0.0f, 150.0f});
   _echelon3->SetPosition(CoffeeMaker::Math::Vector2D{0.0f, 100.0f});
@@ -120,7 +120,7 @@ void TestEchelonScene::Init() {
     _enemies.push_back(e);
     _echelon3->Add(e);
   }
-
+  _player = CreateScope<Player>();
   _player->Init();
 }
 

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -18,7 +18,7 @@ void Logger::Destroy() {
 
 Logger::Logger() {
   _fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>("logs/debug.txt", true);
-  _fileSink->set_level(spdlog::level::debug);
+  _fileSink->set_level(spdlog::level::trace);
 
   _consoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
   _consoleSink->set_level(spdlog::level::trace);
@@ -26,7 +26,9 @@ Logger::Logger() {
   _errSink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
   _errSink->set_level(spdlog::level::critical);
 
-  _spdlog = new spdlog::logger("etc", {_consoleSink, _errSink});
+  _spdlog = new spdlog::logger("Gameplay Log", {_consoleSink, _errSink, _fileSink});
+
+  _spdlog->set_level(spdlog::level::trace);
 }
 
 Logger::~Logger() { delete _spdlog; }

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -21,7 +21,7 @@ Logger::Logger() {
   _fileSink->set_level(spdlog::level::trace);
 
   _consoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-  _consoleSink->set_level(spdlog::level::trace);
+  _consoleSink->set_level(spdlog::level::debug);
 
   _errSink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
   _errSink->set_level(spdlog::level::critical);
@@ -33,13 +33,20 @@ Logger::Logger() {
 
 Logger::~Logger() { delete _spdlog; }
 
-void Logger::Trace(std::string msg) { _logger->_spdlog->trace(msg); }
+void Logger::Trace(fmt::v8::format_string<> fmt) { _logger->_spdlog->trace(fmt); }
 
-void Logger::Debug(std::string msg) { _logger->_spdlog->debug(msg); }
-void Logger::Warn(std::string msg) { _logger->_spdlog->warn(msg); }
-void Logger::Info(std::string msg) { _logger->_spdlog->info(msg); }
-void Logger::Error(std::string msg) { _logger->_spdlog->error(msg); }
-void Logger::Critical(std::string msg) { _logger->_spdlog->critical(msg); }
+void Logger::Debug(fmt::v8::format_string<> fmt, const std::source_location &location) {
+  _logger->_spdlog->debug(fmt::format(fmt::runtime("{} - Source: [ file={}, line={}, function={} ]"), fmt,
+                                      location.file_name(), location.line(), location.function_name()));
+}
+
+void Logger::Warn(fmt::v8::format_string<> fmt) { _logger->_spdlog->warn(fmt); }
+
+void Logger::Info(fmt::v8::format_string<> fmt) { _logger->_spdlog->info(fmt); }
+
+void Logger::Error(fmt::v8::format_string<> fmt) { _logger->_spdlog->error(fmt); }
+
+void Logger::Critical(fmt::v8::format_string<> fmt) { _logger->_spdlog->critical(fmt); }
 
 spdlog::logger *Logger::Instance() {
   if (_logger == nullptr) {

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -35,10 +35,14 @@ Logger::~Logger() { delete _spdlog; }
 
 void Logger::Trace(fmt::v8::format_string<> fmt) { _logger->_spdlog->trace(fmt); }
 
+#ifdef COFFEEMAKER_LOGGER_SOURCE_LOCATION
 void Logger::Debug(fmt::v8::format_string<> fmt, const std::source_location &location) {
   _logger->_spdlog->debug(fmt::format(fmt::runtime("{} - Source: [ file={}, line={}, function={} ]"), fmt,
                                       location.file_name(), location.line(), location.function_name()));
 }
+#else
+void Logger::Debug(fmt::v8::format_string<> fmt) { _logger->_spdlog->debug(fmt::format(fmt::runtime("{}"), fmt)); }
+#endif
 
 void Logger::Warn(fmt::v8::format_string<> fmt) { _logger->_spdlog->warn(fmt); }
 


### PR DESCRIPTION
This PR fixes the player class's duplicate logging that was discovered. This was due to multiple instances of Player being created in separate scenes. From now on, the game will log an error and shut down if multiple Player instances are created.