### PR TITLE
utility window, release builds

### DIFF
--- a/.github/scripts/linux/configure.sh
+++ b/.github/scripts/linux/configure.sh
@@ -4,4 +4,5 @@ cmake --no-warn-unused-cli \
   -DCMAKE_TOOLCHAIN_FILE="/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake" \
   -DCMAKE_C_COMPILER:FILEPATH="/usr/bin/gcc-11" \
   -DCMAKE_CXX_COMPILER:FILEPATH="/usr/bin/g++-11" \
+  -DCOFFEEMAKER_RELEASE_BUILD:BOOL=TRUE \
   -B ./build

--- a/.github/scripts/osx/configure.sh
+++ b/.github/scripts/osx/configure.sh
@@ -4,6 +4,7 @@ cmake --no-warn-unused-cli \
   -DCMAKE_TOOLCHAIN_FILE="/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake" \
   -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
   -DCMAKE_BUILD_TYPE:STRING=Debug \
+  -DCOFFEEMAKER_RELEASE_BUILD:BOOL=TRUE \
   -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/clang \
   -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/clang++ \
   -B ./build \

--- a/.github/scripts/win/configure.bat
+++ b/.github/scripts/win/configure.bat
@@ -1,1 +1,1 @@
-cmake --no-warn-unused-cli -DCMAKE_TOOLCHAIN_FILE:STRING="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -B build -S . -T host=x64 -A x64
+cmake --no-warn-unused-cli -DCMAKE_TOOLCHAIN_FILE:STRING="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCOFFEEMAKER_RELEASE_BUILD:BOOL=TRUE -B build -S . -T host=x64 -A x64

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -127,7 +127,7 @@
   },
   "cmake.configureSettings": {
     "CMAKE_TOOLCHAIN_FILE": "~/vcpkg/scripts/buildsystems/vcpkg.cmake",
-    "COFFEEMAKER_RELEASE_BUILD": true
+    "COFFEEMAKER_RELEASE_BUILD": false
   },
   "[cpp]": {
     "editor.formatOnSave": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -118,10 +118,16 @@
     "source_location": "cpp",
     "__functional_03": "cpp",
     "coroutine": "cpp",
-    "variant": "cpp"
+    "variant": "cpp",
+    "execution": "cpp",
+    "regex": "cpp",
+    "shared_mutex": "cpp",
+    "typeindex": "cpp",
+    "valarray": "cpp"
   },
   "cmake.configureSettings": {
-    "CMAKE_TOOLCHAIN_FILE": "~/vcpkg/scripts/buildsystems/vcpkg.cmake"
+    "CMAKE_TOOLCHAIN_FILE": "~/vcpkg/scripts/buildsystems/vcpkg.cmake",
+    "COFFEEMAKER_RELEASE_BUILD": true
   },
   "[cpp]": {
     "editor.formatOnSave": true,
@@ -134,9 +140,7 @@
     "-Iinclude",
     "-std=c++20"
   ],
-  "clang-tidy.blacklist": [
-    "build/vcpkg_installed/x64-osx/*"
-  ],
+  "clang-tidy.blacklist": ["build/vcpkg_installed/x64-osx/*"],
   "c-cpp-flylint.clang.enable": false,
   "c-cpp-flylint.flawfinder.enable": false,
   "c-cpp-flylint.lizard.enable": false,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,3 +245,9 @@ elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} ST
   message("Compiler is Clang and engine will use <experimental/coroutine> headers")
   add_compile_definitions(COROUTINE_EXPERIMENTAL_SUPPORT)
 endif()
+
+if(COFFEEMAKER_RELEASE_BUILD)
+  message("Generated binary files for COFFEEMAKER_RELEASE_BUILD")
+  add_compile_definitions(COFFEEMAKER_RELEASE_BUILD)
+endif()
+

--- a/include/Async.hpp
+++ b/include/Async.hpp
@@ -40,7 +40,6 @@ namespace CoffeeMaker {
         _packagedTask = new std::packaged_task<T(Args...)>(fp);
         _future = _packagedTask->get_future();
         _thread = new std::thread(std::move(*_packagedTask));
-        std::cout << "Task started!\n";
       }
 
       ~Task() {

--- a/include/Window.hpp
+++ b/include/Window.hpp
@@ -40,6 +40,24 @@ namespace CoffeeMaker {
     virtual ScreenDPI SetScreenDPI() = 0;
   };
 
+  class UtilityWindow {
+    public:
+    UtilityWindow();
+    ~UtilityWindow();
+
+    int DisplayHeight() const;
+    int DisplayWidth() const;
+
+    private:
+    SDL_Window *_handle;
+    SDL_Rect _usableDisplayBounds;
+    SDL_Rect _displayBounds;
+
+    static std::string title;
+    static int width;
+    static int height;
+  };
+
   class BasicWindow : public IWindow {
     public:
     BasicWindow(std::string title, int width, int height, bool fullscreen);
@@ -57,7 +75,6 @@ namespace CoffeeMaker {
     SDL_Window *Handle() const;
     void ShowWindow() const;
     Uint32 GetID() const;
-    void SetOSXWindowedFullscreen();
 
     private:
     ScreenDPI SetScreenDPI();

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -126,10 +126,14 @@ int main(int argc, char** argv) {
   SceneManager::AddScene(new TitleScene());
   SceneManager::AddScene(new MainScene());
   SceneManager::AddScene(new HighScoreScene());
+#ifndef COFFEEMAKER_RELEASE_BUILD
+  // Test scenes we want to expose during development but not in a release build.
+
   // SceneManager::AddScene(new TestBedScene());
   // SceneManager::AddScene(new TestAnimations());
   // SceneManager::AddScene(new TestEchelonScene());
   SceneManager::AddScene(new SplineBuilder());
+#endif
 
   CoffeeMaker::Logger::Debug("Loading scene at index...{}", program.get<int>("--scene"));
   if (!SceneManager::LoadScene(program.get<int>("--scene"))) {

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -94,12 +94,6 @@ int main(int argc, char** argv) {
   CoffeeMaker::Audio::Init();
   CoffeeMaker::Texture::SetTextureDirectory();
 
-  // CoffeeMaker::BasicWindow win("Ultra Cosmo Invaders", 1920, 1080, true); // Linux
-  // CoffeeMaker::BasicWindow win("Ultra Cosmo Invaders", 1792, 1120, true); // OSX
-  // int width = program.get<int>("--display-width");
-  // int height = program.get<int>("--display-height");
-  // bool fullscreen = program.get<bool>("--fullscreen");
-
 #ifdef COFFEEMAKER_RELEASE_BUILD
   int width = utilWindow.DisplayWidth();
   int height = utilWindow.DisplayHeight();

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -89,16 +89,28 @@ int main(int argc, char** argv) {
 
   // SDL_SetAssertionHandler(appHandler, nullptr);
 
+  CoffeeMaker::UtilityWindow utilWindow;
   CoffeeMaker::Utilities::Init(SDL_GetBasePath());
   CoffeeMaker::Audio::Init();
   CoffeeMaker::Texture::SetTextureDirectory();
 
   // CoffeeMaker::BasicWindow win("Ultra Cosmo Invaders", 1920, 1080, true); // Linux
   // CoffeeMaker::BasicWindow win("Ultra Cosmo Invaders", 1792, 1120, true); // OSX
+  // int width = program.get<int>("--display-width");
+  // int height = program.get<int>("--display-height");
+  // bool fullscreen = program.get<bool>("--fullscreen");
+
+#ifdef COFFEEMAKER_RELEASE_BUILD
+  int width = utilWindow.DisplayWidth();
+  int height = utilWindow.DisplayHeight();
+  bool fullscreen = true;
+#else
   int width = program.get<int>("--display-width");
   int height = program.get<int>("--display-height");
   bool fullscreen = program.get<bool>("--fullscreen");
-  CoffeeMaker::BasicWindow win("Ultra Cosmo Invaders", width, height, fullscreen);  // Windows
+#endif
+
+  CoffeeMaker::BasicWindow win("Ultra Cosmo Invaders", width, height, fullscreen);
   CoffeeMaker::Renderer renderer;
 
   std::string basePath = CoffeeMaker::Utilities::BaseDirectory();

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -44,11 +44,7 @@ BasicWindow::BasicWindow(std::string title, int width, int height, bool fullscre
   _dpiScale = _screenDpi.diagonal / ScreenDPI::BASE_DPI;
   SDL_GetDisplayBounds(SDL_GetWindowDisplayIndex(_window), &_screenBounds);
   SDL_GetDisplayUsableBounds(SDL_GetWindowDisplayIndex(_window), &_usableDisplayBounds);
-  CM_LOGGER_INFO("Display Bounds: ({},{}) Display Usable Bounds: ({},{})", _screenBounds.w, _screenBounds.h,
-                 _usableDisplayBounds.w, _usableDisplayBounds.h);
   CM_LOGGER_INFO("Display DPI Scale: {}", _dpiScale);
-  // SDL_SetWindowSize(_window, _usableDisplayBounds.w, _usableDisplayBounds.h);
-  // SDL_SetWindowPosition(_window, 0, 0);
   GlobalWindow::Set(this);
 }
 
@@ -107,18 +103,26 @@ void BasicWindow::ShowWindow() const { SDL_ShowWindow(_window); }
 
 Uint32 BasicWindow::GetID() const { return SDL_GetWindowID(_window); }
 
-void BasicWindow::SetOSXWindowedFullscreen() {
-  // int top = 0;
-  // int left = 0;
-  // int bottom = 0;
-  // int right = 0;
-  // int result = SDL_GetWindowBordersSize(_window, &top, &left, &bottom, &right);
-  // if (result == -1) {
-  //   CM_LOGGER_ERROR("Could not fetch window border size: {}", SDL_GetError());
-  // } else {
-  //   CM_LOGGER_INFO("Window Border Size: ({},{})", right - left, bottom - top);
-  // }
-  // SDL_SetWindowSize(_window, _usableDisplayBounds.w, _usableDisplayBounds.h - 18);
-  // SDL_SetWindowPosition(_window, 0, 0);
-  SDL_SetWindowFullscreen(_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+std::string CoffeeMaker::UtilityWindow::title = "CoffeeMaker";
+int CoffeeMaker::UtilityWindow::width = 800;
+int CoffeeMaker::UtilityWindow::height = 600;
+
+CoffeeMaker::UtilityWindow::UtilityWindow() : _handle(nullptr) {
+  _handle = SDL_CreateWindow(title.c_str(), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height,
+                             SDL_WINDOW_HIDDEN);
+  if (_handle == NULL) {
+    CM_LOGGER_CRITICAL("Could not create utility window.");
+  }
+  SDL_GetDisplayBounds(SDL_GetWindowDisplayIndex(_handle), &_displayBounds);
+  SDL_GetDisplayUsableBounds(SDL_GetWindowDisplayIndex(_handle), &_usableDisplayBounds);
+  CM_LOGGER_INFO("Display Usable Bounds: ({},{})", _usableDisplayBounds.w, _usableDisplayBounds.h);
+  CM_LOGGER_INFO("Display Bounds: ({},{})", _displayBounds.w, _displayBounds.h);
+  SDL_DestroyWindow(_handle);
+  _handle = nullptr;
 }
+
+CoffeeMaker::UtilityWindow::~UtilityWindow() {}
+
+int CoffeeMaker::UtilityWindow::DisplayHeight() const { return _displayBounds.h; }
+
+int CoffeeMaker::UtilityWindow::DisplayWidth() const { return _displayBounds.w; }


### PR DESCRIPTION
This PR introduces a utility window that first launches, grabs display information, and is destroyed. In a release build the width/height will be passed onto the real game window. 